### PR TITLE
Fix hardcoded source quality information

### DIFF
--- a/public/radio-player.js
+++ b/public/radio-player.js
@@ -11,6 +11,7 @@ class RadioPlayer {
         this.dislikeButton = document.getElementById('dislikeButton');
         this.streamUrl = 'https://d3d4yli4hf5bmh.cloudfront.net/hls/live.m3u8';
         this.metadataUrl = 'https://d3d4yli4hf5bmh.cloudfront.net/metadatav2.json';
+        this.DEFAULT_STREAM_QUALITY = '48kHz FLAC / HLS Lossless';
         this.hls = null;
         this.isPlaying = false;
         this.startTime = null;
@@ -196,7 +197,7 @@ class RadioPlayer {
                 }
                 
                 // Stream quality - check if available in metadata, otherwise use default
-                const streamQuality = metadata.stream_quality || '48kHz FLAC / HLS Lossless';
+                const streamQuality = metadata.stream_quality || this.DEFAULT_STREAM_QUALITY;
                 qualityText += `Stream quality: ${streamQuality}`;
                 
                 qualityInfo.innerHTML = qualityText;

--- a/public/radio-player.js
+++ b/public/radio-player.js
@@ -185,8 +185,21 @@ class RadioPlayer {
             if (albumInfo && metadata.album) {
                 albumInfo.textContent = metadata.album;
             }
-            if (qualityInfo && metadata.bit_depth && metadata.sample_rate) {
-                qualityInfo.innerHTML = `Source quality: ${metadata.bit_depth}-bit ${metadata.sample_rate.toLocaleString()}Hz<br>Stream quality: 48kHz FLAC / HLS Lossless`;
+            if (qualityInfo) {
+                let qualityText = '';
+                
+                // Source quality from metadata
+                if (metadata.bit_depth && metadata.sample_rate) {
+                    qualityText += `Source quality: ${metadata.bit_depth}-bit ${metadata.sample_rate.toLocaleString()}Hz<br>`;
+                } else {
+                    qualityText += 'Source quality: Unknown<br>';
+                }
+                
+                // Stream quality - check if available in metadata, otherwise use default
+                const streamQuality = metadata.stream_quality || '48kHz FLAC / HLS Lossless';
+                qualityText += `Stream quality: ${streamQuality}`;
+                
+                qualityInfo.innerHTML = qualityText;
             }
             
             // Update voting info if track changed

--- a/public/radio.html
+++ b/public/radio.html
@@ -33,8 +33,7 @@
                 <h2 class="song-title" id="songTitle">He's A Dream (1983)</h2>
                 <div class="album-info" id="albumInfo">Flashdance (Original Motion Picture Soundtrack)</div>
                 <div class="quality-info" id="qualityInfo">
-                    Source quality: 16-bit 44.1kHz<br>
-                    Stream quality: 48kHz FLAC / HLS Lossless
+                    Loading quality information...
                 </div>
             </div>
             


### PR DESCRIPTION
Fixes #2

This PR addresses the hardcoded source quality issue by:

- Replacing hardcoded quality text in radio.html with a loading state
- Updating radio-player.js to dynamically check for stream_quality in metadata
- Adding fallback handling for missing source quality data
- Stream quality now uses metadata.stream_quality if available, otherwise defaults to existing value

The solution is backward-compatible and gracefully handles missing metadata fields.

Generated with [Claude Code](https://claude.ai/code)